### PR TITLE
Fix typo in substitution definition

### DIFF
--- a/003_lambda_calculus.md
+++ b/003_lambda_calculus.md
@@ -230,7 +230,7 @@ $$
 & [x/a] y          &=& \ y & \text{if}\ x\neq y\\
 & [x/a]ee'         &=& \ ([x/a]e)([x/a]e')\\
 & [x/a]\lambda x.e &=& \ \lambda x.e\\
-& [x/a]\lambda y.e &=& \ \lambda y.[x/a]e & \text{if}\ x \neq y\ \text{and}\ y \notin\FV{e}
+& [x/a]\lambda y.e &=& \ \lambda y.[x/a]e & \text{if}\ x \neq y\ \text{and}\ y \notin\FV{a}
 \end{aligned}
 $$
 


### PR DESCRIPTION
y \notin\FV{e} should be y \notin\FV{a}.