### PR TITLE
Fix tightlist error on pdf generation

### DIFF
--- a/template.latex
+++ b/template.latex
@@ -157,6 +157,8 @@ $endif$
 \setlength{\parindent}{0pt}
 \setlength{\parskip}{6pt plus 2pt minus 1pt}
 \setlength{\emergencystretch}{3em}  % prevent overfull lines
+\providecommand{\tightlist}{%
+  \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 $if(numbersections)$
 \setcounter{secnumdepth}{5}
 $else$


### PR DESCRIPTION
When generating the pdf I got
```
! Undefined control sequence.
l.440 \tightlist
```

This was a bug (already fixed) also on pandoc templates.