### PR TITLE
chapter8: placeholder is indexed from 1 according to Happy User Guide

### DIFF
--- a/008_extended_parser.md
+++ b/008_extended_parser.md
@@ -264,7 +264,7 @@ expression with several metavariable indicated by the dollar sign variables that
 map to the nth expression on the left hand side.
 
 ```
-$0  $1  $2  $3   $4 $5
+$1  $2  $3  $4   $5 $6
 let VAR '=' Expr in Expr    { App (Lam $2 $6) $4 }
 ```
 


### PR DESCRIPTION
According to the official Happy user guide, the index of placeholder for each token is starting from $1, so this may be a typo.