### PR TITLE
007_path.d: ':core id' returns the value, not the type

### DIFF
--- a/007_path.md
+++ b/007_path.md
@@ -311,7 +311,7 @@ plus :: forall a. Num a => a -> a -> a
 
 > :core id
 id :: forall a. a -> a
-id = \(ds1 : a) -> a
+id = \(ds1 : a) -> ds1
 
 > :core compose
 compose :: forall c d e. (d -> e) -> (c -> d) -> c -> e


### PR DESCRIPTION
The example puzzled me until I figured it may be incorrect.
Am I right?