### PR TITLE
fix names for ski combinators

### DIFF
--- a/chapter4/lambda.hs
+++ b/chapter4/lambda.hs
@@ -6,6 +6,6 @@ data Expr
   | Lam Name Expr
 
 s, k, i :: Expr
-s = Lam "x" (Var "x")
+i = Lam "x" (Var "x")
 k = Lam "x" (Lam "y" (Var "x"))
-i = Lam "x" (Lam "y" (Lam "z" (App (App (Var "x") (Var "z")) (App (Var "y") (Var "z")))))
+s = Lam "x" (Lam "y" (Lam "z" (App (App (Var "x") (Var "z")) (App (Var "y") (Var "z")))))


### PR DESCRIPTION
The SKI combinators have been misnamed, this fixes them to match their usual definitions.