### PR TITLE
build with -XFlexibleContexts to make GHC 8.0.2 happy

### DIFF
--- a/chapter9/happy/Makefile
+++ b/chapter9/happy/Makefile
@@ -1,6 +1,6 @@
 all:
 	alex Lexer.x
 	happy Parser.y
-	ghc --make Main -o Main
+	ghc --make Main -o Main -XFlexibleContexts
 clean:
 	rm -f *.o *.hi Parser.hs Lexer.hs Main


### PR DESCRIPTION
This is a workaround for:
```
Lexer.x:66:3: error:
    • Non type-variable argument in the constraint: MonadError [Char] m
      (Use FlexibleContexts to permit this)
    • When checking the inferred type
        go :: forall (m :: * -> *).
              MonadError [Char] m =>
              AlexInput -> m [Token]
      In an equation for ‘scanTokens’:
          scanTokens str
            = go ('\n', [], str)
            where
                go inp@(_, _bs, str)
                  = case alexScan inp 0 of {
                      AlexEOF -> return ...
                      AlexError _ -> throwError "Invalid lexeme."
                      AlexSkip inp' len -> go inp'
                      AlexToken inp' len act -> ... }
Makefile:2: recipe for target 'all' failed
make: *** [all] Error 1
```