### PR TITLE
Small change in token parser.

### DIFF
--- a/chapter3/parsec.hs
+++ b/chapter3/parsec.hs
@@ -92,7 +92,7 @@ string [] = return []
 string (c:cs) = do { char c; string cs; return (c:cs)}
 
 token :: Parser a -> Parser a
-token p = do { a <- p; spaces ; return a}
+token p = do { spaces; a <- p; spaces; return a}
 
 reserved :: String -> Parser String
 reserved s = token (string s)


### PR DESCRIPTION
I'm new to haskell and following this article/tutorial/book. It's very nice thanks for making it!
In my version, adding this change makes sense to me and allows expressions like ```4 * 12``` where the current version only allows ```4* 12``` and ```4*12``` which I find a little strange.