### PR TITLE
poly_constraints: update build

### DIFF
--- a/chapter7/poly_constraints/poly.cabal
+++ b/chapter7/poly_constraints/poly.cabal
@@ -10,14 +10,14 @@ cabal-version:       >=1.10
 
 executable poly
   build-depends:
-      base          >= 4.6   && <4.9
-    , pretty        >= 1.1   && <1.2
-    , parsec        >= 3.1   && <3.2
-    , text          >= 1.2   && <1.3
-    , containers    >= 0.5   && <0.6
-    , mtl           >= 2.2   && <2.3
-    , transformers  >= 0.4.2 && <0.5
-    , repline       >= 0.1.2.0
+      base
+    , pretty
+    , parsec
+    , text
+    , containers
+    , mtl
+    , transformers
+    , repline
 
   other-modules:
     Env

--- a/chapter7/poly_constraints/src/Env.hs
+++ b/chapter7/poly_constraints/src/Env.hs
@@ -64,6 +64,8 @@ fromList xs = TypeEnv (Map.fromList xs)
 toList :: Env -> [(Name, Scheme)]
 toList (TypeEnv env) = Map.toList env
 
+instance Semigroup Env where
+  (<>) = merge
+
 instance Monoid Env where
   mempty = empty
-  mappend = merge

--- a/chapter7/poly_constraints/src/Infer.hs
+++ b/chapter7/poly_constraints/src/Infer.hs
@@ -51,7 +51,7 @@ type Unifier = (Subst, [Constraint])
 type Solve a = ExceptT TypeError Identity a
 
 newtype Subst = Subst (Map.Map TVar Type)
-  deriving (Eq, Ord, Show, Monoid)
+  deriving (Eq, Ord, Show, Semigroup, Monoid)
 
 class Substitutable a where
   apply :: Subst -> a -> a

--- a/chapter7/poly_constraints/src/Pretty.hs
+++ b/chapter7/poly_constraints/src/Pretty.hs
@@ -18,7 +18,7 @@ import Type
 import Syntax
 import Infer
 
-import Text.PrettyPrint
+import Text.PrettyPrint hiding ((<>))
 import qualified Data.Map as Map
 
 parensIf ::  Bool -> Doc -> Doc
@@ -45,7 +45,7 @@ instance Pretty Type where
 
 instance Pretty Scheme where
   ppr p (Forall [] t) = ppr p t
-  ppr p (Forall ts t) = text "forall" <+> hcat (punctuate space (map (ppr p) ts)) <> text "." <+> ppr p t
+  ppr p (Forall ts t) = text "forall" <+> (hcat (punctuate space (map (ppr p) ts)) <> (text "." <+> ppr p t))
 
 instance Pretty Binop where
   ppr _ Add = text "+"
@@ -56,15 +56,16 @@ instance Pretty Binop where
 instance Pretty Expr where
   ppr p (Var a) = ppr p a
   ppr p (App a b) = parensIf (p > 0) $ ppr (p+1) a <+> ppr p b
-  ppr p (Lam a b) = text "\\" <> ppr p a <+> text  "->" <+> ppr p b
-  ppr p (Let a b c) = text "let" <> ppr p a <+> text  "=" <+> ppr p b <+> text "in" <+> ppr p c
+  ppr p (Lam a b) = text "\\" <> (ppr p a <+> text  "->" <+> ppr p b)
+  ppr p (Let a b c) = text "let" <> (ppr p a <+> text  "=" <+> ppr p b <+> text "in" <+> ppr p c)
   ppr p (Lit a) = ppr p a
   ppr p (Op o a b) = parensIf (p>0) $ ppr p a <+> ppr p o <+> ppr p b
   ppr p (Fix a) = parensIf (p>0) $ text "fix" <> ppr p a
   ppr p (If a b c) =
-    text "if" <> ppr p a <+>
-    text "then" <+> ppr p b <+>
-    text "else" <+> ppr p c
+    text "if" <>
+      (ppr p a <+>
+       text "then" <+> ppr p b <+>
+       text "else" <+> ppr p c)
 
 instance Pretty Lit where
   ppr _ (LInt i) = integer i


### PR DESCRIPTION
hi, thanks for the excellent project!

I just got `poly_constraints` to build with GHC 8.6.5. I cut all the version bounds out in order to do so, and am not sure what they should be. so, I don't really think this PR is mergeable, and maybe should serve more as a reference. hopefully it save some people some time 🙂 

the changes were around Semigroup/Monoid, MonadFail, `pretty` operator precedence (code is untested; just typechecked), `repline` (API changes).

for reference, the `cabal.project.freeze`:

```
constraints: any.array ==0.5.3.0,
             any.base ==4.12.0.0,
             any.binary ==0.8.6.0,
             any.bytestring ==0.10.8.2,
             any.containers ==0.6.0.1,
             any.deepseq ==1.4.4.0,
             any.directory ==1.3.3.0,
             any.exceptions ==0.10.4,
             exceptions +transformers-0-4,
             any.filepath ==1.4.2.1,
             any.ghc-boot-th ==8.6.5,
             any.ghc-prim ==0.5.3,
             any.haskeline ==0.8.1.0,
             haskeline +examples +terminfo,
             any.integer-gmp ==1.0.2.0,
             any.mtl ==2.2.2,
             any.parsec ==3.1.13.0,
             any.pretty ==1.1.3.6,
             any.process ==1.6.5.0,
             any.repline ==0.4.0.0,
             any.rts ==1.0,
             any.stm ==2.5.0.0,
             any.template-haskell ==2.14.0.0,
             any.terminfo ==0.4.1.2,
             any.text ==1.2.3.1,
             any.time ==1.8.0.2,
             any.transformers ==0.5.6.2,
             any.unix ==2.7.2.2
```