### PR TITLE
Fix parsing of binop

### DIFF
--- a/chapter7/poly/src/Parser.hs
+++ b/chapter7/poly/src/Parser.hs
@@ -17,7 +17,7 @@ import Lexer
 import Syntax
 
 integer :: Parser Integer
-integer = Tok.integer lexer
+integer = Tok.natural lexer
 
 variable :: Parser Expr
 variable = do

--- a/chapter7/poly_constraints/src/Parser.hs
+++ b/chapter7/poly_constraints/src/Parser.hs
@@ -17,7 +17,7 @@ import Lexer
 import Syntax
 
 integer :: Parser Integer
-integer = Tok.integer lexer
+integer = Tok.natural lexer
 
 variable :: Parser Expr
 variable = do


### PR DESCRIPTION
Related to #110 

Using `Tok.integer` causes the operators to be eaten before they are seen as infixOps. By reading numbers as naturals the operators `+` and `-` are treated as we expect.